### PR TITLE
correct link to wiki for " +x" items

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -301,7 +301,7 @@ function getCard(item_name, category_name) {
 					 title="${item_name}">
 <br>
 <p class="card-text">${item_name}</p>
-<a href="https://eldenring.wiki.fextralife.com/${item_name.replaceAll(" ", "+")}" class="stretched-link" target="_blank"> </a> </div>
+<a href="https://eldenring.wiki.fextralife.com/${item_name.replace(/ \+\d+$/, "").replaceAll(" ", "+")}" class="stretched-link" target="_blank"> </a> </div>
 </div>`;
 }
 


### PR DESCRIPTION
Talismans +X were linked to non existent wiki pages. For exemple, Erdtree's+Favor +2 sent to https://eldenring.wiki.fextralife.com/Erdtree's+Favor++2.
I correct this to the +0 pages (https://eldenring.wiki.fextralife.com/Erdtree's+Favor) which also contain the description of the +X variants.